### PR TITLE
force production env when precompiling assets

### DIFF
--- a/lib/capistrano/tasks/compile_assets_locally.cap
+++ b/lib/capistrano/tasks/compile_assets_locally.cap
@@ -2,11 +2,11 @@ namespace :deploy do
   desc "compiles assets locally then rsyncs"
   task :compile_assets_locally do
     run_locally do
-      execute "bundle exec rake assets:precompile"
+      execute "RAILS_ENV=#{fetch(:rails_env)} bundle exec rake assets:precompile"
     end
     on roles(:app) do |role|
       run_locally do
-        execute"rsync -av ./public/assets/ #{role.user}@#{role.hostname}:#{release_path}/public/assets/;" 
+        execute"rsync -av ./public/assets/ #{role.user}@#{role.hostname}:#{release_path}/public/assets/;"
       end
     end
     run_locally do


### PR DESCRIPTION
I was having the same issue detailed at http://stackoverflow.com/questions/19086898/image-path-production-reference-is-not-working-in-rails-4

Assets in production were being served without finger-printed names.

Forcing the env to be production when compiling the assets locally fixed this - although with a catch - you need to have a 'production' database defined in database.yml  in order for it to work. I can just be the exact same as your development database - it'll never actually get used.

Dunno if you want to merge this PR - it seems like there should be a better solution, that doesn't require you to edit your database.yml also. But if there is a better solution, I'd love to know it. Either way, it's an issue that needs to be resolved somehow.

Signed-off-by: Joshua Paling joshua.paling@gmail.com
