### PR TITLE
Add all available commands in Unicorn to Capistrano tasks

### DIFF
--- a/lib/capistrano/tasks/restart.cap
+++ b/lib/capistrano/tasks/restart.cap
@@ -1,8 +1,10 @@
 namespace :deploy do
-  desc 'Restart unicorn application'
-  task :restart do
-    on roles(:app), in: :sequence, wait: 5 do
-      sudo "/etc/init.d/unicorn_#{fetch(:full_app_name)} restart"
+  desc 'Commands for unicorn application'
+  %w(start stop force-stop kill_worker restart upgrage reopen-logs).each do |command|
+    task command.to_sym do
+      on roles(:app), in: :sequence, wait: 5 do
+        sudo "/etc/init.d/unicorn_#{fetch(:full_app_name)} #{command}"
+      end
     end
   end
 end


### PR DESCRIPTION
Thank you for recipes for Capistrano.
"Stop" and "start" commands in unicorn is also useful.
I've added all available commands for current `unicorn_init.sh` script.
I hope it will be useful.
