### PR TITLE
Change Permissions on assets explicitly for Rails 4.1 

### DIFF
--- a/lib/capistrano/tasks/compile_assets_locally.cap
+++ b/lib/capistrano/tasks/compile_assets_locally.cap
@@ -8,6 +8,7 @@ namespace :deploy do
       run_locally do
         execute"rsync -av ./public/assets/ #{role.user}@#{role.hostname}:#{release_path}/public/assets/;"
       end
+      sudo "chmod -R 755 #{release_path}/public/assets/"
     end
     run_locally do
       execute "rm -rf ./public/assets"


### PR DESCRIPTION
On rails 4.1 the assets folder is set 644 and owned by deploy:deploy.

So the nginx www-data user is not able to render any pictures. So we need to change the permissions to 755, as it was on rails 4.0 and prior.

This is my suggestion.
