### PR TITLE
fix RAILS_ENV environment in precompiling assets

### DIFF
--- a/lib/capistrano/tasks/compile_assets_locally.cap
+++ b/lib/capistrano/tasks/compile_assets_locally.cap
@@ -2,7 +2,7 @@ namespace :deploy do
   desc "compiles assets locally then rsyncs"
   task :compile_assets_locally do
     run_locally do
-      execute "RAILS_ENV=#{fetch(:rails_env)} bundle exec rake assets:precompile"
+      execute "bundle exec rake assets:precompile RAILS_ENV=#{fetch(:rails_env)}"
     end
     on roles(:app) do |role|
       run_locally do


### PR DESCRIPTION
When `RAILS_ENV=#{fetch(:rails_env)}` is before `bundle`, capistrano comes up with a `no such directory` error.
